### PR TITLE
Capture last capturing element

### DIFF
--- a/src/main/java/io/jonuuh/core/lib/gui/AbstractGuiScreen.java
+++ b/src/main/java/io/jonuuh/core/lib/gui/AbstractGuiScreen.java
@@ -168,12 +168,16 @@ public abstract class AbstractGuiScreen extends GuiScreen
 
         if (!clickable.isEmpty())
         {
-            // TODO: should currentFocus be an InputListener?
-            currentFocus = CollectionUtils.getMax(clickable, Comparator.comparingInt(GuiElement::getZLevel));
+            // TODO: if the clickable elements contains a scroll slider, reverse order to get min z level instead?
+            //  desired behavior may be that when a click is performed on two overlapping scroll sliders from a parent container and its child container,
+            //  the parent container's scroll slider wins (parent scroll slider z level would be lower than the child scroll slider if zLevel=numParents)
+            GuiElement mouseDownTarget = CollectionUtils.getMax(clickable, Comparator.comparingInt(GuiElement::getZLevel));
 
+            MouseDownEvent event = new MouseDownEvent(mouseDownTarget, mouseX, mouseY);
+            dispatchTargetedEvent(event);
+
+            currentFocus = event.getLastCapture();
             System.out.println("greatestZElement: " + currentFocus);
-
-            dispatchTargetedEvent(new MouseDownEvent(currentFocus, mouseX, mouseY));
         }
     }
 

--- a/src/main/java/io/jonuuh/core/lib/gui/event/GuiTargetedEvent.java
+++ b/src/main/java/io/jonuuh/core/lib/gui/event/GuiTargetedEvent.java
@@ -5,12 +5,18 @@ import io.jonuuh.core.lib.gui.element.GuiElement;
 public abstract class GuiTargetedEvent extends GuiEvent
 {
     public final GuiElement target;
+    protected GuiElement lastCapture;
     private boolean propagationStopped;
 
     protected GuiTargetedEvent(GuiElement target)
     {
         this.target = target;
         this.propagationStopped = false;
+    }
+
+    public GuiElement getLastCapture()
+    {
+        return lastCapture;
     }
 
     public void stopPropagation()

--- a/src/main/java/io/jonuuh/core/lib/gui/event/input/KeyInputEvent.java
+++ b/src/main/java/io/jonuuh/core/lib/gui/event/input/KeyInputEvent.java
@@ -22,6 +22,7 @@ public class KeyInputEvent extends GuiTargetedEvent
         if (element instanceof KeyInputListener)
         {
             ((KeyInputListener) element).onKeyTyped(this);
+            lastCapture = element;
         }
     }
 }

--- a/src/main/java/io/jonuuh/core/lib/gui/event/input/MouseDownEvent.java
+++ b/src/main/java/io/jonuuh/core/lib/gui/event/input/MouseDownEvent.java
@@ -22,6 +22,7 @@ public class MouseDownEvent extends GuiTargetedEvent
         if (element instanceof MouseClickListener)
         {
             ((MouseClickListener) element).onMouseDown(this);
+            lastCapture = element;
         }
     }
 }

--- a/src/main/java/io/jonuuh/core/lib/gui/event/input/MouseDragEvent.java
+++ b/src/main/java/io/jonuuh/core/lib/gui/event/input/MouseDragEvent.java
@@ -26,6 +26,7 @@ public class MouseDragEvent extends GuiTargetedEvent
         if (element instanceof MouseDragListener)
         {
             ((MouseDragListener) element).onMouseDrag(this);
+            lastCapture = element;
         }
     }
 }

--- a/src/main/java/io/jonuuh/core/lib/gui/event/input/MouseScrollEvent.java
+++ b/src/main/java/io/jonuuh/core/lib/gui/event/input/MouseScrollEvent.java
@@ -20,6 +20,7 @@ public class MouseScrollEvent extends GuiTargetedEvent
         if (element instanceof MouseScrollListener)
         {
             ((MouseScrollListener) element).onMouseScroll(this);
+            lastCapture = element;
         }
     }
 }

--- a/src/main/java/io/jonuuh/core/lib/gui/event/input/MouseUpEvent.java
+++ b/src/main/java/io/jonuuh/core/lib/gui/event/input/MouseUpEvent.java
@@ -22,6 +22,7 @@ public class MouseUpEvent extends GuiTargetedEvent
         if (element instanceof MouseClickListener)
         {
             ((MouseClickListener) element).onMouseUp(this);
+            lastCapture = element;
         }
     }
 }


### PR DESCRIPTION
The `currentFocus` of `AbstractGuiScreen` needs to be set to whatever element last captured the `MouseDownEvent` (the end of the propagation path).

Previous behavior:
- `currentFocus` would be set to the greatest `zLevel` clickable element before every `MouseDownEvent`.
- This is more or less always setting `currentFocus` to the end of the propagation path.

New behavior:
- If the event propagates down to and is handled by the intended target, `currentFocus` will be set to that target (same as the previous behavior).
- But, if the event propagation is stopped early by an intermediary element, `currentFocus` will be set to that element instead.

Motivation:
- `GuiDropdown` is a container wrapping a list of `GuiButton`s, but the container should intercept and handle the clicks on its children.
- Despite this, during a `MouseDownEvent` on the `GuiDropdown`, the previous behavior would have still set `currentFocus` to the `GuiButton` which was intercepted and thus not "focused".